### PR TITLE
Adding Prometheus JMX Exporter to Collect metrics on Hawkular Services

### DIFF
--- a/containers/images/hawkular-mock-agent-inventory/hawkular-mock-agent-inventory.py
+++ b/containers/images/hawkular-mock-agent-inventory/hawkular-mock-agent-inventory.py
@@ -57,6 +57,8 @@ class AgentLifeCycle(TaskSet):
 class HawkularAgent(HttpLocust):
     task_set = AgentLifeCycle
     host = resources.get_url()
+    global execution
+    execution = "execution" + str(uuid.uuid4())
     min_wait = resources.get_milliseconds_request()
     max_wait = resources.get_milliseconds_request()
     resources.create_database()
@@ -68,10 +70,11 @@ class HawkularAgent(HttpLocust):
 
     def hook_request_success(self, request_type, name, response_time, response_length):
         metrics = {}
-        tags = {'agent': feed}
+        tags = {'execution': execution}
         metrics['measurement'] = "request"
         fields = {'request_type': request_type,
                   'request_increment': 1,
+                  'agent': feed,
                   'response_time': response_time, 'response_length': response_length,
                   'name': name}
         metrics['fields'] = fields

--- a/containers/images/jmx_exporter/Dockerfile
+++ b/containers/images/jmx_exporter/Dockerfile
@@ -1,0 +1,13 @@
+FROM hawkular/hawkular-services:latest
+
+EXPOSE 5556 5555
+
+USER root
+
+# Set up the Prometheus endpoint for monitoring
+RUN cd $JBOSS_HOME/bin && \
+    curl -Lo $JBOSS_HOME/bin/jmx_prometheus_javaagent.jar https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.9/jmx_prometheus_javaagent-0.9.jar
+
+ADD prometheus.yaml ${JBOSS_HOME}/configuration/prometheus.yaml
+
+RUN echo 'JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=org.jboss.byteman,org.jboss.logmanager -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5555 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:$JBOSS_HOME/bin/jmx_prometheus_javaagent.jar=5556:${JBOSS_HOME}/configuration/prometheus.yaml"' >> $JBOSS_HOME/bin/standalone.conf

--- a/containers/images/jmx_exporter/prometheus.yaml
+++ b/containers/images/jmx_exporter/prometheus.yaml
@@ -1,0 +1,7 @@
+# ---
+# hostPort: 127.0.0.1:5555
+# ssl: false
+#
+#
+# rules:
+# - pattern: ".*"


### PR DESCRIPTION
 - Using Prometheus JMX Exporter (https://github.com/prometheus/jmx_exporter) to collect hawkular services' metrics on prometheus.

- Metrics to be collected 
       - jvm_memory_bytes_used{area="heap",}
       - jvm_memory_bytes_used{area="nonheap",}
       - jvm_memory_bytes_committed{area="heap",}
       - jvm_memory_bytes_committed{area="nonheap",}
       - jvm_memory_pool_bytes_committed{pool="Code Cache",}
       - jvm_memory_bytes_max{area="heap",}
       - jvm_memory_bytes_max{area="nonheap",}
       - jvm_memory_pool_bytes_used{pool="Code Cache",}
       - jvm_memory_pool_bytes_used{pool="Metaspace",}
       - jvm_memory_pool_bytes_used{pool="Compressed Class Space",}
       - jvm_memory_pool_bytes_used{pool="PS Eden Space",}
       - jvm_memory_pool_bytes_used{pool="PS Survivor Space",}
       - jvm_memory_pool_bytes_used{pool="PS Old Gen",}
       - jvm_memory_pool_bytes_committed{pool="Code Cache",}
       - jvm_memory_pool_bytes_committed{pool="Metaspace",}
       - jvm_memory_pool_bytes_committed{pool="Compressed Class Space",}
       - jvm_memory_pool_bytes_committed{pool="PS Eden Space",}
       - jvm_memory_pool_bytes_committed{pool="PS Survivor Space",}
       - jvm_memory_pool_bytes_committed{pool="PS Old Gen",}
       - jvm_memory_pool_bytes_max{pool="Code Cache",}
       - jvm_memory_pool_bytes_max{pool="Compressed Class Space",}
       - jvm_memory_pool_bytes_max{pool="PS Eden Space",}
       - jvm_memory_pool_bytes_max{pool="PS Survivor Space",}
       - jvm_memory_pool_bytes_max{pool="PS Old Gen",}

The Hawkular Services + Prometheus JMX image was submmited to https://hub.docker.com/r/gbaufake/hawkular-services-jmx/